### PR TITLE
recognize .hpp as header file

### DIFF
--- a/src/pconfigure/lang/h.c
+++ b/src/pconfigure/lang/h.c
@@ -91,7 +91,7 @@ struct language *language_h_search(struct language *l_uncast,
 
     if ((strcmp(path + strlen(path) - 2, ".h") != 0)
         && (strcmp(path + strlen(path) - 4, ".h++") != 0)
-	&& (strcmp(path + strlen(path) - 4, ".hpp") != 0))
+        && (strcmp(path + strlen(path) - 4, ".hpp") != 0))
         return NULL;
 
     if (parent == NULL)


### PR DESCRIPTION
.hpp is a common file extension for C++ header files.
This ought to be recognized by pconfigure as such.
