### PR TITLE
Handle ".." in SRCDIR

### DIFF
--- a/src/pconfigure/lang/c.c
+++ b/src/pconfigure/lang/c.c
@@ -21,6 +21,7 @@
 
 #include "c.h"
 #include "funcs.h"
+#include "str.h"
 #include <string.h>
 #include <unistd.h>
 
@@ -181,7 +182,7 @@ const char *language_c_objname(struct language *l_uncast, void *context,
         suffix = "o";
 
     o = talloc_asprintf(context, "%s/%s/%s-%s-%s-%s-%s.%s",
-                        c->obj_dir, c->full_path,
+                        c->obj_dir, remove_dotdot(subcontext, c->full_path),
                         compiler_hash, compileopts_hash, langopts_hash,
                         prefix_hash,
                         c->shared_target ? "shared" : "static", suffix);

--- a/src/pconfigure/lang/chisel.c
+++ b/src/pconfigure/lang/chisel.c
@@ -24,6 +24,7 @@
 #include "chisel.h"
 #include "ftwfn.h"
 #include "funcs.h"
+#include "str.h"
 #include "../languagelist.h"
 #include <ftw.h>
 #include <string.h>
@@ -202,8 +203,8 @@ const char *language_chisel_objname(struct language *l_uncast, void *context,
     assert(c->full_path[strlen(c->src_dir)] == '/');
 
     o = talloc_asprintf(context, "%s/%s/%s-%s-%s-chisel_c.o",
-                        c->obj_dir,
-                        c->full_path, compileopts_hash, langopts_hash,
+                        c->obj_dir, remove_dotdot(subcontext, c->full_path),
+                        compileopts_hash, langopts_hash,
                         c->shared_target ? "shared" : "static");
 
     TALLOC_FREE(subcontext);

--- a/src/pconfigure/lang/flo.c
+++ b/src/pconfigure/lang/flo.c
@@ -25,6 +25,7 @@
 #include "ftwfn.h"
 #include "funcs.h"
 #include "../languagelist.h"
+#include "str.h"
 #include <ftw.h>
 #include <string.h>
 #include <unistd.h>
@@ -196,8 +197,8 @@ const char *language_flo_objname(struct language *l_uncast, void *context,
     assert(c->full_path[strlen(c->src_dir)] == '/');
 
     o = talloc_asprintf(context, "%s/%s/%s-%s-%s-chisel_flo.o",
-                        c->obj_dir,
-                        c->full_path, compileopts_hash, langopts_hash,
+                        c->obj_dir, remove_dotdot(subcontext, c->full_path),
+                        compileopts_hash, langopts_hash,
                         c->shared_target ? "shared" : "static");
 
     TALLOC_FREE(subcontext);

--- a/src/pconfigure/lang/scala.c
+++ b/src/pconfigure/lang/scala.c
@@ -24,6 +24,7 @@
 #include "ftwfn.h"
 #include "funcs.h"
 #include "scala.h"
+#include "str.h"
 #include <ftw.h>
 #include <string.h>
 #include <unistd.h>
@@ -153,8 +154,8 @@ const char *language_scala_objname(struct language *l_uncast, void *context,
     assert(c->full_path[strlen(c->src_dir)] == '/');
 
     o = talloc_asprintf(context, "%s/%s/%s-%s.jar",
-                        c->obj_dir,
-                        c->full_path, compileopts_hash, langopts_hash);
+                        c->obj_dir, remove_dotdot(subcontext, c->full_path),
+                        compileopts_hash, langopts_hash);
 
     TALLOC_FREE(subcontext);
     return o;

--- a/src/pconfigure/lang/str.c
+++ b/src/pconfigure/lang/str.c
@@ -22,6 +22,12 @@
 #include "str.h"
 #include <string.h>
 
+#ifdef HAVE_TALLOC
+#include <talloc.h>
+#else
+#include "extern/talloc.h"
+#endif
+
 bool str_sta(const char *haystack, const char *needle)
 {
     if (haystack == NULL)
@@ -30,4 +36,20 @@ bool str_sta(const char *haystack, const char *needle)
         return false;
 
     return (strncmp(haystack, needle, strlen(needle)) == 0);
+}
+
+const char *remove_dotdot(void *c, const char *str)
+{
+    char *out;
+    size_t i;
+
+    out = talloc_strdup(c, str);
+    for (i = 0; i < strlen(str); ++i) {
+        if (strncmp(str + i, "..", 2) == 0) {
+            out[i + 0] = '_';
+            out[i + 1] = '_';
+        }
+    }
+
+    return out;
 }

--- a/src/pconfigure/lang/str.h
+++ b/src/pconfigure/lang/str.h
@@ -27,4 +27,8 @@
 /* Returns TRUE if "haystack" starts with "needle". */
 bool str_sta(const char *haystack, const char *needle);
 
+/* Replaces all instances of ".." with "__", to remove extra path
+ * specifiers. */
+const char *remove_dotdot(void *c, const char *str);
+
 #endif


### PR DESCRIPTION
I generate object directories as something like

  OBJDIR/SRCDIR/PATH/hash.o

which fails when SRCDIR has some ".."s in it.  This just replaces all
instances of ".." with "__" when generating object file names -- it's
a bit conservative, but since these names are entirely internal it
doesn't matter at all.

Hopefully this fixes

  https://github.com/palmer-dabbelt/pconfigure/issues/4