### PR TITLE
Fix Clang builds

### DIFF
--- a/src/libmakefile/makefile.c++
+++ b/src/libmakefile/makefile.c++
@@ -3,23 +3,22 @@
  *   <palmer@dabbelt.com>
  *
  * This file is part of pconfigure.
- * 
+ *
  * pconfigure is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * pconfigure is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with pconfigure.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "makefile.h++"
-using namespace makefile;
 
 makefile::makefile::makefile(void)
 {


### PR DESCRIPTION
Clang doesn't seem to like that file:

```
C++	libmakefile/makefile.c++
src/libmakefile/makefile.c++:24:1: error: 'makefile' is not a class, namespace,
      or enumeration
makefile::makefile::makefile(void)
^
src/libmakefile/makefile.c++:24:1: error: reference to 'makefile' is ambiguous
makefile::makefile::makefile(void)
^
src/libmakefile/makefile.h++:26:11: note: candidate found by name lookup is
      'makefile'
namespace makefile {
          ^
src/libmakefile/makefile.h++:31:11: note: candidate found by name lookup is
      'makefile::makefile'
    class makefile {
          ^
2 errors generated.
make: *** [obj/src/libmakefile/makefile.c++/3116907492-5381-3680455565-1948174428-static.o] Error 1
```

The `using namespace` declaration is kind of useless at the moment, anyway.

My editor seems also to have stripped some whitespace.