### PR TITLE
Define __PCONFIGURE_DEPS when gathering deps for C sources

### DIFF
--- a/src/pconfigure/lang/c.c
+++ b/src/pconfigure/lang/c.c
@@ -232,6 +232,7 @@ void language_c_deps(struct language *l_uncast, struct context *c,
         lang_wo = stringlist_without(l->l.compile_opts, context, "-fopenmp");
         ctx_wo = stringlist_without(c->compile_opts, context, "-fopenmp");
 
+        stringlist_add(ctx_wo, talloc_strdup(l, "-D__PCONFIGURE_DEPS"));
         clang_argc = stringlist_size(lang_wo) + stringlist_size(ctx_wo) + 3;
         clang_argv = talloc_array(context, char *, clang_argc + 1);
         for (i = 0; i <= clang_argc; i++)


### PR DESCRIPTION
This is *very* handy in very specific certain situations...
