### PR TITLE
Make #ifdef *not* crash if given tabs

### DIFF
--- a/src/libpinclude/library.c
+++ b/src/libpinclude/library.c
@@ -94,7 +94,8 @@ static int _pinclude_lines(const char *input,
 
         /* Here's where we handle the #if{,n}def preprocessor
          * directives. */
-        if (strncmp(buffer, "#ifdef ", strlen("#ifdef ")) == 0) {
+        if (strncmp(buffer, "#ifdef ", strlen("#ifdef ")) == 0 ||
+            strncmp(buffer, "#ifdef\t", strlen("#ifdef\t")) == 0) {
             char *define;
             bool matched;
 
@@ -115,7 +116,8 @@ static int _pinclude_lines(const char *input,
 #endif
         }
 
-        if (strncmp(buffer, "#ifndef ", strlen("#ifndef ")) == 0) {
+        if (strncmp(buffer, "#ifndef ", strlen("#ifndef ")) == 0 ||
+            strncmp(buffer, "#ifndef\t", strlen("#ifndef\t")) == 0) {
             char *define;
             bool matched;
 

--- a/src/pconfigure/lang/c.c
+++ b/src/pconfigure/lang/c.c
@@ -232,6 +232,7 @@ void language_c_deps(struct language *l_uncast, struct context *c,
         lang_wo = stringlist_without(l->l.compile_opts, context, "-fopenmp");
         ctx_wo = stringlist_without(c->compile_opts, context, "-fopenmp");
 
+        stringlist_add(ctx_wo, talloc_strdup(l, "-D__PCONFIGURE_DEPS"));
         clang_argc = stringlist_size(lang_wo) + stringlist_size(ctx_wo) + 3;
         clang_argv = talloc_array(context, char *, clang_argc + 1);
         for (i = 0; i <= clang_argc; i++)


### PR DESCRIPTION
Apparently this:

```c
#ifdef<tab>x
```

is legal C, which bit my when trying to compile Plan 9's libregexp with pconfigure because I'm embedding it into my application.
