### PR TITLE
Fix regex escaping incompatibility

### DIFF
--- a/src/libpconfigure/languages/cxx.c++
+++ b/src/libpconfigure/languages/cxx.c++
@@ -274,7 +274,9 @@ language_cxx::find_files_for_header(const std::string& full_header_path) const
 
     std::vector<std::regex> remove_patterns = {
         std::regex("(.*)\\.h"),
-        std::regex("(.*)\\.h++")
+#if ((__GNUC__ != 4) || (__GNUC_MINOR__ > 8))
+        std::regex("(.*)\\.h\\+\\+")
+#endif
     };
 
     std::vector<std::string> add_patterns = {
@@ -282,9 +284,13 @@ language_cxx::find_files_for_header(const std::string& full_header_path) const
         "$1.c"
     };
 
+    const auto regex_flags = std::regex_constants::format_no_copy;
     for (const auto& remove: remove_patterns) {
         for (const auto& add: add_patterns) {
-            std::string f = std::regex_replace(full_header_path, remove, add);
+            std::string f = std::regex_replace(full_header_path,
+                                               remove,
+                                               add,
+                                               regex_flags);
             if (access(f.c_str(), R_OK) == 0)
                 out.push_back(f);
         }


### PR DESCRIPTION
The regex to detect C++ headers with extension `.h++` seems malformed to me because fails to escape the plus character.  LLVM's libc++ even throws a `regex_error` exception when it tries to compile it, but for some reason the GNU equivalent throws an error on the __escaped__ version.  I don't see how the unescaped one can possibly be correct, nor do I understand why the escaped variant fails on GCC 4.8, but this fix seems to work for both cases.