### PR TITLE
Use -rpath @executable_path for OSX local builds

### DIFF
--- a/src/libpconfigure/languages/cxx.c++
+++ b/src/libpconfigure/languages/cxx.c++
@@ -350,7 +350,11 @@ language_cxx::link_target::generate_makefile_target(void) const
         {
             switch (_shared) {
             case shared_target::TRUE:
+#ifdef __APPLE__
+                return " -shared -Wl,-install_name,@rpath/" + _ctx->cmd->data();
+#else
                 return " -shared";
+#endif
             case shared_target::FALSE:
                 return "";
             }


### PR DESCRIPTION
Rather than trying all sorts of install_name_tool stuff, just use the build-in
@executable_path stuff on OSX (which works just like $ORIGIN on Linux).